### PR TITLE
Revert "PKGBUILD: unset CC and CXX aswell"

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -83,8 +83,6 @@ build() {
   }
 
   unset_flags() {
-    unset CC
-    unset CXX
     unset CFLAGS
     unset CXXFLAGS
   }


### PR DESCRIPTION
[1] seems to cause issues with static_assert, hence dropping it is wise.

[1]: 1c2a36a8

Test: Compiled GLIBC 2.35 successfully with [1] reverted.
Signed-off-by: Cyber Knight <cyberknight755@gmail.com>